### PR TITLE
Configurable default no mob spawning/no hunger loss

### DIFF
--- a/src/main/java/xyz/ttryy/extendedbeacon/listener/BlockPlaceListener.java
+++ b/src/main/java/xyz/ttryy/extendedbeacon/listener/BlockPlaceListener.java
@@ -1,21 +1,21 @@
 package xyz.ttryy.extendedbeacon.listener;
 
-import com.google.common.collect.Lists;
+//import com.google.common.collect.Lists;
 import org.bukkit.Material;
 import org.bukkit.block.Beacon;
-import org.bukkit.enchantments.Enchantment;
+//import org.bukkit.enchantments.Enchantment;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
-import org.bukkit.event.block.BlockBreakEvent;
+//import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
-import org.bukkit.inventory.ItemFlag;
+//import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.meta.ItemMeta;
+//import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.persistence.PersistentDataType;
 import xyz.ttryy.extendedbeacon.main.ExtendedBeaconPlugin;
 import xyz.ttryy.extendedbeacon.utils.Messages;
 
-import java.util.List;
+//import java.util.List;
 
 public class BlockPlaceListener implements Listener {
 
@@ -41,6 +41,7 @@ public class BlockPlaceListener implements Listener {
         boolean mobSpawning = beaconItem.getItemMeta().getPersistentDataContainer().has(plugin.getTorchedKey(), PersistentDataType.INTEGER) &&
                 beaconItem.getItemMeta().getPersistentDataContainer().get(plugin.getTorchedKey(), PersistentDataType.INTEGER) == 1;
 
+
         if(hunger || mobSpawning){
             if (hunger) {
                 beacon.getPersistentDataContainer().set(plugin.getHungerKey(), PersistentDataType.INTEGER, 1);
@@ -56,6 +57,27 @@ public class BlockPlaceListener implements Listener {
             beacon.update();
         }
 
+        //adding in default buffs. STH 2022-0210
+        boolean defaultMobSpawning = plugin.getDefaultStopMobSpawn();
+        boolean defaultHunger = plugin.getDefaultStopHunger();
+        if(defaultHunger || defaultMobSpawning){
+            if (defaultMobSpawning) {
+                beacon.getPersistentDataContainer().set(plugin.getTorchedKey(), PersistentDataType.INTEGER, 1);
+                Messages.NO_MOB_SPAWNING.send(event.getPlayer());
+                if(!plugin.getBeacons().contains(beacon.getLocation())){
+                    plugin.getBeacons().add(beacon.getLocation());
+                }
+            }
+            if (defaultHunger) {
+                beacon.getPersistentDataContainer().set(plugin.getHungerKey(), PersistentDataType.INTEGER, 1);
+                Messages.NO_HUNGER.send(event.getPlayer());
+                if(!plugin.getBeacons().contains(beacon.getLocation())){
+                    plugin.getBeacons().add(beacon.getLocation());
+                }
+            }
+            beacon.update();
+        }
+        //#############
 
     }
 

--- a/src/main/java/xyz/ttryy/extendedbeacon/main/ExtendedBeaconPlugin.java
+++ b/src/main/java/xyz/ttryy/extendedbeacon/main/ExtendedBeaconPlugin.java
@@ -23,6 +23,11 @@ public class ExtendedBeaconPlugin extends JavaPlugin {
     private boolean customReason;
     private List<EntityType> whitelist;
 
+    //adding in default buffs. STH 2022-0210
+    private boolean defaultStopMobSpawn;
+    private boolean defaultStopHunger;
+    //#######
+
     @Override
     public void onEnable() {
         instance = this;
@@ -51,6 +56,10 @@ public class ExtendedBeaconPlugin extends JavaPlugin {
     private void loadConfig(){
         whitelist = Lists.newArrayList();
         customReason = getConfig().getBoolean("mob_spawning.block_custom_reason", false);
+        //adding in default buffs. STH 2022-0210
+        defaultStopMobSpawn = getConfig().getBoolean("default.stop_mob_spawning", false);
+        defaultStopHunger = getConfig().getBoolean("default.stop_hunger", false);
+        //#######
         getConfig().getStringList("mob_spawning.whitelist").forEach(type -> {
             if(EntityType.valueOf(type) != null) whitelist.add(EntityType.valueOf(type));
         });
@@ -90,5 +99,13 @@ public class ExtendedBeaconPlugin extends JavaPlugin {
 
     public static ExtendedBeaconPlugin getInstance() {
         return instance;
+    }
+
+    public boolean getDefaultStopMobSpawn() {
+        return defaultStopMobSpawn;
+    }
+
+    public boolean getDefaultStopHunger() {
+        return defaultStopHunger;
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,6 +13,10 @@ mob_spawning:
   block_custom_reason: false
   whitelist: []
 
+default:
+  stop_mob_spawning: true
+  stop_hunger: false
+  
 messages:
   MOB_SPAWNING: "&eMobs can spawn in your beacon radius."
   NO_MOB_SPAWNING: "&eMobs can no longer spawn in your beacon radius."


### PR DESCRIPTION
Code changes that allow the admin to decide whether newly placed beacons start out blocking mob spawning and/or stop hunger loss

Compiled and tested against 1.18